### PR TITLE
Updated the documentation to use PERLDB_OPTS

### DIFF
--- a/Devel/Debug/DBGp.pm
+++ b/Devel/Debug/DBGp.pm
@@ -8,7 +8,7 @@ Devel::Debug::DBGp - Perl DBGp debugger (derived from Komodo remote debugging he
 
 From the command line:
 
-    DBGP_OPTS="RemotePort=localhost:9000" perl -I/path/to/lib/dbgp-helper -d myscript.pl
+    PERLDB_OPTS="RemotePort=localhost:9000" perl -I/path/to/lib/dbgp-helper -d myscript.pl
 
 From an helper module:
 

--- a/Devel/Debug/DBGp.pm
+++ b/Devel/Debug/DBGp.pm
@@ -9,6 +9,12 @@ Devel::Debug::DBGp - Perl DBGp debugger (derived from Komodo remote debugging he
 From the command line:
 
     PERLDB_OPTS="RemotePort=localhost:9000" perl -I/path/to/lib/dbgp-helper -d myscript.pl
+    
+You can get the path of dbgp-helper by running something like:
+
+    [user@user]~% reply
+    0> use Devel::Debug::DBGp;
+    1> print Devel::Debug::DBGp->debugger_path
 
 From an helper module:
 


### PR DESCRIPTION
DBGP_OPTS doesn't seem to be considered when running the scripts from the command line. Only PERLDB_OPTS does. 

E.g. The following works:

```
PERLDB_OPTS="RemotePath=/var/run/dbgp/uwsgi.sock" perl -I/usr/lib/pakket/5.24.3/libraries/active/lib/perl5/x86_64-linux/dbgp-helper -d hello.pl
```
But this doesn't:

```
DBGP_OPTS="RemotePath=/var/run/dbgp/uwsgi.sock" perl -I/usr/lib/pakket/5.24.3/libraries/active/lib/perl5/x86_64-linux/dbgp-helper -d hello.pl
```