### PR TITLE
Fix 5.37.9 breakage due to eval errors being handled consistently in modern perls.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -67,7 +67,7 @@ WriteMakefile(
     },
     clean             => { FILES => 'DB/DbgrXS.pm' },
     $do_xs ? (
-        XS                => { 'perl5db.xs' => undef },
+        XS                => { 'perl5db.xs' => 'perl5db.c' },
         OBJECT            => 'perl5db.o',
     ) : (
         XS                => { },

--- a/t/152_property_set.t
+++ b/t/152_property_set.t
@@ -156,7 +156,10 @@ command_is(['property_get', '-n', '%foo'], {
 command_is(['property_set', '-n', '$foo', '--', encode_base64('(aaa')], {
     apperr  => 4,
     code    => 207,
-    message => "syntax error\n",
+    message => ($^V < 5.37.9
+                ? "syntax error\n"
+                : "syntax error at (eval 18)[blib/lib/dbgp-helper/perl5db.pl:192] line 1, at EOF\n" .
+                  "Execution of (eval 18)[blib/lib/dbgp-helper/perl5db.pl:192] aborted due to compilation errors.\n"),
     command => 'property_set',
 });
 


### PR DESCRIPTION
Errors are now consistently handled in eval, regardless of count, or type of error (semantic or syntax, etc). In older perls a single syntax error would not trigger `$SIG{__DIE__}` for instance, nor would it exit the eval the same way as 10+ errors would. In 5.37.9 all errors are handled the same, and will trigger `$SIG{__DIE__}`, and output the "Execution of ... aborted due to compilation errors" message always now.

Fixes https://github.com/mbarbon/perl-remote-debugging-client/issues/7